### PR TITLE
Add rule to resolve import extensions

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,10 +8,13 @@ module.exports = {
     path: path.join(__dirname, '/client/dist'),
     filename: 'bundle.js',
   },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
   module: {
     rules: [
       {
-        test: /\.js[x]?$/,
+        test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: 'babel-loader',
       },


### PR DESCRIPTION
Modified webpack to make it aware of `.js` and `.jsx` extensions for imports.

You can now import `App.jsx` as `App`, and the linter won't complain about it!