### PR TITLE
Add global box-sizing and color palette vars

### DIFF
--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,0 +1,15 @@
+* {
+  /* fix some mis-alignment issues */
+  box-sizing: border-box;
+}
+
+:root {
+  /* Color Palette variables */
+  --kombu-green: #283618ff;
+  --ebony: #5e6748ff;
+  --artichoke: #939878ff;
+  --dutch-white: #d8cba7ff;
+  --french-bistre: #866c46ff;
+  --pullman-brown-ups-brown: #5a3b16ff;
+  --cafe-noir: #4f3517ff;
+}


### PR DESCRIPTION
The box-sizing attribute should prevent some CSS misalignment issues while we're fine tuning position and size of elements

The color palette vars are attached to the root pseudo-class, so they should be available in all of your style sheets!

Usage example:
```CSS
button {
  background-color: var(--kombu-green);
}
```